### PR TITLE
feat: integrate volume data and strategy state into candlestick chart

### DIFF
--- a/bot-ui-ts/src/components/CandlestickChart.tsx
+++ b/bot-ui-ts/src/components/CandlestickChart.tsx
@@ -1,73 +1,88 @@
 import React, { useEffect, useRef } from 'react';
-import { 
-    ColorType, 
-    createChart, 
-    IChartApi, 
-    ISeriesApi,
-    SeriesMarker,
-    SeriesMarkerPosition,
-    SeriesMarkerShape 
-} from 'lightweight-charts';
-import { BotTrade, Candle } from '../types';
+import { ColorType, createChart, IChartApi, ISeriesApi, PriceLineOptions, SeriesMarker, SeriesMarkerPosition, SeriesMarkerShape, IPriceLine, LineStyle } from 'lightweight-charts';
+import { BotTrade, Candle, StrategyState, VolumeData } from '../types';
 
 interface CandlestickChartProps {
     initialData: Candle[] | null;
+    initialVolume: VolumeData[] | null;
     update: Candle | null;
+    volumeUpdate: VolumeData | null;
     botTrades: BotTrade[];
+    strategyState: StrategyState | null; // <<< NEW: Accept strategy state
 }
 
-const CandlestickChart: React.FC<CandlestickChartProps> = ({ initialData, update, botTrades }) => {
+const CandlestickChart: React.FC<CandlestickChartProps> = ({ initialData, initialVolume, update, volumeUpdate, botTrades, strategyState }) => {
     const chartContainerRef = useRef<HTMLDivElement>(null);
     const chartRef = useRef<IChartApi | null>(null);
-    const seriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
+    const candleSeriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
+    const volumeSeriesRef = useRef<ISeriesApi<'Histogram'> | null>(null);
+    
+    // <<< NEW: Refs to hold all our strategy lines ---
+    const entryPriceLineRef = useRef<IPriceLine | null>(null);
+    const stopLossLineRef = useRef<IPriceLine | null>(null);
+    const takeProfitLineRefs = useRef<(IPriceLine | null)[]>([]);
 
     useEffect(() => {
+        // Chart and series initialization remains the same...
         if (!chartContainerRef.current) return;
-        const chart = createChart(chartContainerRef.current, {
-            layout: { background: { type: ColorType.Solid, color: 'transparent' }, textColor: 'rgba(255, 255, 255, 0.7)' },
-            grid: { vertLines: { color: 'rgba(255, 255, 255, 0.1)' }, horzLines: { color: 'rgba(255, 255, 255, 0.1)' } },
-            timeScale: { timeVisible: true, secondsVisible: false },
-            autoSize: true, 
-        });
-        
-        const series = chart.addCandlestickSeries({
-            upColor: '#26a69a', downColor: '#ef5350',
-            borderVisible: false,
-            wickUpColor: '#26a69a', wickDownColor: '#ef5350',
-        });
+        const chart = createChart(chartContainerRef.current, { /* ...options... */ autoSize: true, layout: { background: { type: ColorType.Solid, color: 'transparent' }, textColor: 'rgba(255, 255, 255, 0.7)'}, grid: { vertLines: { color: 'rgba(255, 255, 255, 0.1)' }, horzLines: { color: 'rgba(255, 255, 255, 0.1)' }}, timeScale: { timeVisible: true, secondsVisible: false }});
+        const candleSeries = chart.addCandlestickSeries({ upColor: '#26a69a', downColor: '#ef5350', borderVisible: false, wickUpColor: '#26a69a', wickDownColor: '#ef5350' });
+        const volumeSeries = chart.addHistogramSeries({ priceFormat: { type: 'volume' }, priceScaleId: '', lastValueVisible: false, priceLineVisible: false });
+        chart.priceScale('').applyOptions({ scaleMargins: { top: 0.85, bottom: 0 } });
         
         chartRef.current = chart;
-        seriesRef.current = series;
-        
-        return () => {
-            chart.remove();
-        };
+        candleSeriesRef.current = candleSeries;
+        volumeSeriesRef.current = volumeSeries;
+
+        return () => chart.remove();
     }, []);
 
+    // Data update hooks remain the same...
     useEffect(() => {
-        if (initialData && seriesRef.current) {
-            seriesRef.current.setData(initialData);
-        }
-    }, [initialData]);
+        if (initialData && candleSeriesRef.current) candleSeriesRef.current.setData(initialData);
+        if (initialVolume && volumeSeriesRef.current) volumeSeriesRef.current.setData(initialVolume);
+    }, [initialData, initialVolume]);
 
     useEffect(() => {
-        if (update && seriesRef.current) {
-            seriesRef.current.update(update);
-        }
-    }, [update]);
+        if (update && candleSeriesRef.current) candleSeriesRef.current.update(update);
+        if (volumeUpdate && volumeSeriesRef.current) volumeSeriesRef.current.update(volumeUpdate);
+    }, [update, volumeUpdate]);
 
+    // Bot trade markers hook remains the same...
     useEffect(() => {
-        if (botTrades && seriesRef.current) {
-            const markers: SeriesMarker<typeof botTrades[0]['time']>[] = botTrades.map(trade => ({
-                time: trade.time,
-                position: (trade.side === 'BUY' ? 'belowBar' : 'aboveBar') as SeriesMarkerPosition,
-                color: trade.side === 'BUY' ? '#2196F3' : '#F44336',
-                shape: (trade.side === 'BUY' ? 'arrowUp' : 'arrowDown') as SeriesMarkerShape,
-                text: `${trade.side} @ ${trade.price.toFixed(6)}`
-            }));
-            seriesRef.current.setMarkers(markers);
+        if (botTrades && candleSeriesRef.current) {
+            const markers: SeriesMarker<any>[] = botTrades.map(trade => ({ time: trade.time, position: (trade.side === 'BUY' ? 'belowBar' : 'aboveBar') as SeriesMarkerPosition, color: trade.side === 'BUY' ? '#2196F3' : '#F44336', shape: (trade.side === 'BUY' ? 'arrowUp' : 'arrowDown') as SeriesMarkerShape, text: `${trade.side} @ ${trade.price.toFixed(6)}`, size: 1.2 }));
+            candleSeriesRef.current.setMarkers(markers);
         }
     }, [botTrades]);
+
+    // <<< NEW: A dedicated hook to draw and update all strategy lines ---
+    useEffect(() => {
+        if (!strategyState || !candleSeriesRef.current) return;
+
+        // --- 1. Entry Price Line (create once) ---
+        if (!entryPriceLineRef.current) {
+            entryPriceLineRef.current = candleSeriesRef.current.createPriceLine({ price: strategyState.entry_price, color: '#2196F3', lineWidth: 1, lineStyle: LineStyle.Dashed, axisLabelVisible: true, title: 'ENTRY' });
+        }
+
+        // --- 2. Stop-Loss Line (create or update) ---
+        if (!stopLossLineRef.current) {
+            stopLossLineRef.current = candleSeriesRef.current.createPriceLine({ price: strategyState.stop_loss_price, color: '#FFEB3B', lineWidth: 2, lineStyle: LineStyle.Solid, axisLabelVisible: true, title: 'STOP' });
+        } else {
+            // Update the stop-loss line's price if it changes (for trailing stops)
+            stopLossLineRef.current.applyOptions({ price: strategyState.stop_loss_price });
+        }
+        
+        // --- 3. Take-Profit Lines (create once) ---
+        if (takeProfitLineRefs.current.length === 0) {
+            strategyState.take_profit_tiers.forEach(([targetPercent], i) => {
+                const targetPrice = strategyState.entry_price * (1 + targetPercent);
+                const tpLine = candleSeriesRef.current!.createPriceLine({ price: targetPrice, color: '#4CAF50', lineWidth: 1, lineStyle: LineStyle.Dotted, axisLabelVisible: true, title: `TP ${i + 1}` });
+                takeProfitLineRefs.current.push(tpLine);
+            });
+        }
+
+    }, [strategyState]);
 
     return <div ref={chartContainerRef} className="w-full h-full" />;
 };

--- a/bot-ui-ts/src/types.ts
+++ b/bot-ui-ts/src/types.ts
@@ -45,3 +45,9 @@ export interface StrategyState {
     stop_loss_price: number;
     take_profit_tiers: [number, number][]; // Array of tuples [target_percent, sell_portion]
 }
+
+export interface VolumeData {
+  time: Time;
+  value: number;
+  color: string;
+}


### PR DESCRIPTION
This pull request enhances the functionality of the trading bot UI by introducing volume data visualization and integrating strategy state into the candlestick chart. The changes include updates to the `CandlestickChart` component, state management in `App.tsx`, and the addition of a new `VolumeData` type. Below are the most important changes:

### Volume Data Integration:
* Added `VolumeData` type to represent volume data with `time`, `value`, and `color` fields (`bot-ui-ts/src/types.ts`).
* Updated `App.tsx` to manage `initialVolume` and `lastVolume` states and handle volume data in WebSocket messages (`bot-ui-ts/src/App.tsx`) [[1]](diffhunk://#diff-07d9a699e704f060ba8135532589158c996b416743a66a2400944ae5af863e50L40-R51) [[2]](diffhunk://#diff-07d9a699e704f060ba8135532589158c996b416743a66a2400944ae5af863e50R66-R71).
* Enhanced `CandlestickChart` to display volume data using a histogram series and update it dynamically (`bot-ui-ts/src/components/CandlestickChart.tsx`).

### Strategy State Integration:
* Modified `CandlestickChart` to accept `strategyState` and display strategy-related lines (entry price, stop-loss, and take-profit tiers) (`bot-ui-ts/src/components/CandlestickChart.tsx`).
* Updated the `App.tsx` chart component to pass `strategyState` as a prop (`bot-ui-ts/src/App.tsx`).

These updates improve the chart's usability by providing more comprehensive trading insights, including volume trends and strategy visualization.